### PR TITLE
🐛🛠 Fix days on details page + search field input

### DIFF
--- a/components/com_fabrik/views/details/tmpl/cci_search_engine/default.php
+++ b/components/com_fabrik/views/details/tmpl/cci_search_engine/default.php
@@ -44,6 +44,7 @@ if ($this->params->get('show_page_heading', 1)) : ?>
     $address = $this->data['jos_emundus_setup_teaching_unity___location_address_raw'];
     $addTitle = $this->data['jos_emundus_setup_teaching_unity___location_title_raw'];
     $partenaire = str_replace(' ', '-', trim(strtolower($this->data['jos_emundus_setup_programmes___partner_raw'])));
+    $days = trim($this->data['jos_emundus_setup_teaching_unity___days_raw']);
     $certificate = str_replace(' ', '-', trim(strtolower($this->data['jos_emundus_setup_programmes___certificate_raw'])));
 
     echo $this->plugintop;
@@ -85,7 +86,14 @@ if ($this->params->get('show_page_heading', 1)) : ?>
                     <?php echo $duree_svg; ?>
                 </div>
                 <div class="em-days">
-                    <p id="days"></p>
+                    <p id="days">
+                        <?php
+                        if ($days > 1)
+                            echo $days." jours";
+                        elseif ($days = 1)
+                            echo $days." jour";
+                        ?>
+                    </p>
                 </div>
             </div>
 
@@ -233,10 +241,14 @@ if ($this->params->get('show_page_heading', 1)) : ?>
 
                                 <p>
                                     <?php
-                                        if (!empty($session['tax_rate']))
-                                            echo intval($session['price']) . " € HT" ;
-                                        else
-                                            echo intval($session['price']) . " € net" ;
+                                        if ($partenaire == 'esi')
+                                            echo intval($session['price']) . " € TTC" ;
+                                        else {
+                                            if (!empty($session['tax_rate']))
+                                                echo intval($session['price']) . " € HT" ;
+                                            else
+                                                echo intval($session['price']) . " € net" ;
+                                        }
                                     ?>
                                 </p>
 
@@ -427,10 +439,6 @@ if ($this->params->get('show_page_heading', 1)) : ?>
 
 
     jQuery(document).ready(function() {
-        if (sessions[0]['days'] > 1)
-            document.getElementById("days").append((sessions[0]['days']) + " jours");
-        else
-            document.getElementById("days").append((sessions[0]['days']) + " jour");
 
         var options = document.getElementById("formation-options");
         options.appendChild(document.getElementById("em-formation-options"));

--- a/components/com_fabrik/views/details/tmpl/cci_search_engine/default.php
+++ b/components/com_fabrik/views/details/tmpl/cci_search_engine/default.php
@@ -88,9 +88,9 @@ if ($this->params->get('show_page_heading', 1)) : ?>
                 <div class="em-days">
                     <p id="days">
                         <?php
-                        if ($days > 1)
+                        if (floatval($days) > 1)
                             echo $days." jours";
-                        elseif ($days = 1)
+                        elseif (floatval($days) == 1)
                             echo $days." jour";
                         ?>
                     </p>

--- a/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
+++ b/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
@@ -101,7 +101,7 @@ if (!empty($cible)) {
         break;
 
         default:
-            $cible = strtolower($cible);
+            $cible = strtoupper($cible);
         break;
 
     }

--- a/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
+++ b/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
@@ -269,7 +269,7 @@ if(!empty($category)) {
                 no_results_text: "<?php echo JText::_('CHOSEN_NO_RESULTS'); ?>"
             });
 
-            <?php if (!empty(JFactory::getApplication()->input->post->get('search'))) :?>
+            <?php if (!empty(JFactory::getApplication()->input->post->getString('search'))) :?>
                 document.getElementById("formation-search").value = '<?php echo JFactory::getApplication()->input->post->get('search'); ?>';
             <?php endif; ?>
 

--- a/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
+++ b/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
@@ -149,7 +149,9 @@ if(!empty($category)) {
 
                                 foreach ($data as $d) {
 
-                                    $days = jsonDecode($d['jos_emundus_setup_teaching_unity___days_raw'])[0];
+                                    $days = jsonDecode($d['jos_emundus_setup_teaching_unity___days_raw']);
+                                    if (is_array($days))
+                                        $days = $days[0];
 	                                $title = jsonDecode($d['jos_emundus_setup_teaching_unity___label_raw']);
 	                                if (is_array($title))
 		                                $title = $title[0];
@@ -204,9 +206,9 @@ if(!empty($category)) {
                                             <div  class="em-day-details">
                                                 <p>
                                                     <?php
-                                                    if ($days > 1)
+                                                    if (floatval($days) > 1)
                                                         echo $days." jours";
-                                                    elseif ($days = 1)
+                                                    elseif (floatval($days) == 1)
                                                         echo $days." jour";
                                                     ?>
                                                 </p>

--- a/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
+++ b/components/com_fabrik/views/list/tmpl/cci_search_engine/default.php
@@ -64,6 +64,7 @@ $telechargement_svg = file_get_contents(JPATH_BASE.DS."images".DS."custom".DS."c
 
 
 $category = JFactory::getApplication()->input->get->get('category');
+$cible = JFactory::getApplication()->input->get->get('cible');
 if(!empty($category)) {
     $db = JFactory::getDbo();
     $query = $db->getQuery(true);
@@ -77,6 +78,36 @@ if(!empty($category)) {
     $category = $db->loadAssoc();
 }
 
+if (!empty($cible)) {
+    switch ($cible) {
+        case 'dirigeant' :
+            $cible = "DIRIGEANT";
+        break;
+
+        case 'salarie':
+            $cible = "SALARIÉ";
+        break;
+
+        case 'hotel-restaurant' :
+            $cible = "HÔTELIER - RESTAURATEUR";
+        break;
+
+        case 'immobilier' :
+            $cible = "PROFESSIONNEL DE L’IMMOBILIER";
+        break;
+
+        case 'createur' :
+            $cible = "CRÉATEUR - REPRENEUR D’ENTREPRISE";
+        break;
+
+        default:
+            $cible = strtolower($cible);
+        break;
+
+    }
+}
+
+
 ?>
 
 <div class="main">
@@ -87,6 +118,15 @@ if(!empty($category)) {
                 <div class="theme-filter">
                     <div class="em-themes em-theme-title em-theme-<?php echo $category['color']; ?>">
                         <?php echo $category['label']; ?>
+                    </div>
+                    <a href="/rechercher?resetfilters=0&clearordering=0&clearfilters=0"><span aria-hidden="true">&times;</span></a>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!empty($cible)) :?>
+                <div class="theme-filter">
+                    <div class="em-filter-cible">
+                        <?php echo $cible; ?>
                     </div>
                     <a href="/rechercher?resetfilters=0&clearordering=0&clearfilters=0"><span aria-hidden="true">&times;</span></a>
                 </div>


### PR DESCRIPTION
Search page : 
input field was using get->get() to show text in text area, but it was removing spaces and accents.
Now using get->getString() which should fix the problem

Details page: 
putting the days straight into the html tags and NOT going through jS ( no idea why i did that..) 